### PR TITLE
Add swagger spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # meeting-scheduler-api
+
+SWAGGER: <img src="http://online.swagger.io/validator?url=https://raw.githubusercontent.com/zednis/meeting-scheduler-api/add_swagger_spec/swagger.yml">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-# meeting-scheduler-api
-
-SWAGGER: <img src="http://online.swagger.io/validator?url=https://raw.githubusercontent.com/zednis/meeting-scheduler-api/add_swagger_spec/swagger.yml">
+# meeting-scheduler-api <img src="http://online.swagger.io/validator?url=https://raw.githubusercontent.com/zednis/meeting-scheduler-api/add_swagger_spec/swagger.yml">

--- a/swagger.yml
+++ b/swagger.yml
@@ -168,6 +168,22 @@ paths:
 
     get:
       summary: Retrieve List of User Records
+      parameters:
+        - in: query
+          name: email
+          description: user email
+          required: false
+          type: string
+        - in: query
+          name: givenName
+          description: firstname/given name
+          required: false
+          type: string
+        - in: query
+          name: familyName
+          description: lastname/family name
+          required: false
+          type: string
       tags:
         - Users
       responses:

--- a/swagger.yml
+++ b/swagger.yml
@@ -118,7 +118,7 @@ paths:
       parameters:
         - $ref: "#/parameters/roomName"
       tags:
-        - Room
+        - Rooms
       responses:
         200:
           description: OK

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,0 +1,425 @@
+swagger: '2.0'
+info:
+  title: Meeting Scheduler API
+  contact:
+    name: API Support
+    email: zednis@rpi.edu
+  version: 1.0.0
+schemes:
+  - http
+produces:
+  - application/json
+tags:
+- name: Meetings
+- name: Users
+- name: Room
+paths:
+
+  /api/room:
+
+    post:
+      summary: Create Meeting Room Record
+      parameters:
+        - name: create meeting room request object
+          in: body
+          description: create meeting room request object
+          required: true
+          schema:
+            $ref: "#/definitions/CreateMeetingRoomRequest"
+      tags:
+      - Room
+      responses:
+        201:
+          description: Created
+          headers:
+            Location:
+              description: relative URL to created meeting room record
+              type: string
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+    get:
+      summary: Retrieve List of Meeting Room Records
+      tags:
+        - Room
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ListOfMeetingRoomInfo"
+
+  /api/room/{roomName}:
+
+    get:
+      summary: Retrieve Meeting Room Record
+      parameters:
+        - $ref: "#/parameters/roomName"
+      tags:
+        - Room
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/MeetingRoomInfo"
+
+    put:
+      summary: Update Meeting Room Record
+      parameters:
+        - $ref: "#/parameters/roomName"
+      tags:
+        - Room
+      responses:
+        200:
+          description: OK
+
+    delete:
+      summary: Delete Meeting Room Record
+      parameters:
+        - $ref: "#/parameters/roomName"
+      tags:
+        - Room
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+
+  /api/room/{roomName}/meetings:
+
+    get:
+      summary: Retrieve List of Meeting Records for Meeting Room
+      parameters:
+        - $ref: "#/parameters/roomName"
+      tags:
+        - Room
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ListOfMeetingInfo"
+
+  /api/user:
+
+    post:
+      summary: Create User Record
+      parameters:
+        - name: create user request object
+          in: body
+          description: create user request object
+          required: true
+          schema:
+            $ref: "#/definitions/CreateUserRequest"
+      tags:
+        - Users
+      responses:
+        201:
+          description: Created
+          headers:
+            Location:
+              description: relative URL to created user record
+              type: string
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+    get:
+      summary: Retrieve List of User Records
+      tags:
+        - Users
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ListOfUserInfo"
+
+
+  /api/user/{userId}:
+
+    get:
+      summary: Retrieve User Record
+      parameters:
+        - $ref: "#/parameters/userId"
+      tags:
+        - Users
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/UserInfo"
+
+    delete:
+      summary: Delete User Record
+      parameters:
+        - $ref: "#/parameters/userId"
+      tags:
+        - Users
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+
+  /api/user/{userId}/meetings:
+
+    get:
+      summary: Retrieve List of Meeting Records for User
+      parameters:
+        - $ref: "#/parameters/userId"
+      tags:
+        - Users
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ListOfMeetingInfo"
+
+  /api/meeting:
+
+    post:
+      summary: Create Meeting Record
+      parameters:
+        - name: create meeting request object
+          in: body
+          description: create meeting request object
+          required: true
+          schema:
+            $ref: "#/definitions/CreateMeetingRequest"
+      tags:
+        - Meetings
+      responses:
+        201:
+          description: Created
+          headers:
+            Location:
+              description: relative URL to created meeting record
+              type: string
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+  /api/meeting/{meetingId}:
+
+    get:
+      summary: Retrieve Meeting Record
+      parameters:
+      - $ref: "#/parameters/meetingId"
+      tags:
+       - Meetings
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/MeetingInfo"
+
+    put:
+      summary: Update Meeting Record
+      parameters:
+      - $ref: "#/parameters/meetingId"
+      - name: meeting object
+        in: body
+        description: meeting description
+        required: true
+        schema:
+          $ref: "#/definitions/MeetingInfo"
+      tags:
+      - Meetings
+      responses:
+        200:
+          description: OK
+
+    delete:
+      summary: Delete Meeting Record
+      parameters:
+      - $ref: '#/parameters/meetingId'
+      tags:
+       - Meetings
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+parameters:
+
+  roomName:
+    name: roomName
+    in: path
+    description: meeting room name
+    required: true
+    type: string
+
+  meetingId:
+    name: meetingId
+    in: path
+    description: meeting identifier
+    required: true
+    type: string
+
+  userId:
+    name: userId
+    in: path
+    description: user identifier
+    required: true
+    type: string
+
+
+definitions:
+
+  CreateMeetingRoomRequest:
+    type: object
+    properties:
+      name:
+        type: string
+      resources:
+        type: array
+        items:
+          type: string
+    required:
+      - name
+      - resources
+
+  ActionResponse:
+    type: object
+    properties:
+      requestURL:
+        type: string
+      action:
+        type: string
+      status:
+        type: number
+      message:
+        type: string
+      timestamp:
+        type: string
+        format: date-time
+    required:
+      - requestURL
+      - action
+      - status
+      - message
+      - timestamp
+
+  MeetingRoomInfo:
+    type: object
+    properties:
+      name:
+        type: string
+      resources:
+        type: array
+        items:
+          type: string
+      createdAt:
+        type: string
+        format: date-time
+    required:
+      - name
+      - resources
+      - createdAt
+
+  ListOfMeetingRoomInfo:
+    type: object
+    properties:
+      rooms:
+        type: array
+        items:
+          $ref: "#/definitions/MeetingRoomInfo"
+    required:
+      - rooms
+
+  CreateUserRequest:
+    type: object
+    properties:
+      givenName:
+        type: string
+      familyName:
+        type: string
+      email:
+        type: string
+    required:
+      - givenName
+      - familyName
+      - email
+
+  UserInfo:
+    type: object
+    properties:
+      userId:
+        type: string
+      givenName:
+        type: string
+      familyName:
+        type: string
+      email:
+        type: string
+      createdAt:
+        type: string
+        format: date-time
+    required:
+      - userId
+      - givenName
+      - familyName
+      - email
+      - createdAt
+
+  ListOfUserInfo:
+    type: object
+    properties:
+      users:
+        type: array
+        items:
+          $ref: "#/definitions/UserInfo"
+    required:
+      - users
+
+  CreateMeetingRequest:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      startDateTime:
+        type: string
+        format: date-time
+      endDateTime:
+        type: string
+        format: date-time
+    required:
+      - name
+      - startDateTime
+      - endDateTime
+
+  MeetingInfo:
+    type: object
+    properties:
+      meetingId:
+        type: string
+      name:
+        type: string
+      description:
+        type: string
+      startDateTime:
+        type: string
+        format: date-time
+      endDateTime:
+        type: string
+        format: date-time
+      createdAt:
+        type: string
+        format: date-time
+    required:
+      - meetingId
+      - name
+      - startDateTime
+      - endDateTime
+      - createdAt
+
+  ListOfMeetingInfo:
+    type: object
+    properties:
+      meetings:
+        type: array
+        items:
+          $ref: "#/definitions/MeetingInfo"
+    required:
+      - meetings

--- a/swagger.yml
+++ b/swagger.yml
@@ -12,7 +12,7 @@ produces:
 tags:
 - name: Meetings
 - name: Users
-- name: Room
+- name: Rooms
 paths:
 
   /api/room:
@@ -27,7 +27,7 @@ paths:
           schema:
             $ref: "#/definitions/CreateMeetingRoomRequest"
       tags:
-      - Room
+      - Rooms
       responses:
         201:
           description: Created
@@ -41,7 +41,7 @@ paths:
     get:
       summary: Retrieve List of Meeting Room Records
       tags:
-        - Room
+        - Rooms
       responses:
         200:
           description: OK
@@ -55,29 +55,55 @@ paths:
       parameters:
         - $ref: "#/parameters/roomName"
       tags:
-        - Room
+        - Rooms
       responses:
         200:
           description: OK
           schema:
             $ref: "#/definitions/MeetingRoomInfo"
 
-    put:
+    patch:
       summary: Update Meeting Room Record
       parameters:
         - $ref: "#/parameters/roomName"
+        - name: patch request
+          in: body
+          description: patch request
+          required: true
+          schema:
+            $ref: "#/definitions/PatchRequest"
       tags:
-        - Room
+        - Rooms
       responses:
         200:
           description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+    put:
+      summary: Replace Meeting Room Record
+      parameters:
+        - $ref: "#/parameters/roomName"
+        - name: meeting room record
+          in: body
+          required: true
+          description: meeting room record
+          schema:
+            $ref: "#/definitions/MeetingRoomInfo"
+      tags:
+        - Rooms
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
 
     delete:
       summary: Delete Meeting Room Record
       parameters:
         - $ref: "#/parameters/roomName"
       tags:
-        - Room
+        - Rooms
       responses:
         200:
           description: OK
@@ -147,6 +173,42 @@ paths:
           schema:
             $ref: "#/definitions/UserInfo"
 
+    patch:
+      summary: Update User Record
+      parameters:
+        - $ref: "#/parameters/userId"
+        - name: patch request
+          in: body
+          description: patch request
+          required: true
+          schema:
+            $ref: "#/definitions/PatchRequest"
+      tags:
+        - Users
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+    put:
+      summary: Replace User Record
+      parameters:
+        - $ref: "#/parameters/userId"
+        - name: user record
+          in: body
+          description: user record
+          required: true
+          schema:
+            $ref: "#/definitions/UserInfo"
+      tags:
+        - Users
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
     delete:
       summary: Delete User Record
       parameters:
@@ -211,13 +273,31 @@ paths:
           schema:
             $ref: "#/definitions/MeetingInfo"
 
-    put:
+    patch:
       summary: Update Meeting Record
       parameters:
+        - $ref: "#/parameters/meetingId"
+        - name: patch request
+          in: body
+          description: patch request
+          required: true
+          schema:
+            $ref: "#/definitions/PatchRequest"
+      tags:
+        - Meetings
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
+
+    put:
+      summary: Replace Meeting Record
+      parameters:
       - $ref: "#/parameters/meetingId"
-      - name: meeting object
+      - name: meeting record
         in: body
-        description: meeting description
+        description: meeting record
         required: true
         schema:
           $ref: "#/definitions/MeetingInfo"
@@ -226,6 +306,8 @@ paths:
       responses:
         200:
           description: OK
+          schema:
+            $ref: "#/definitions/ActionResponse"
 
     delete:
       summary: Delete Meeting Record
@@ -264,6 +346,31 @@ parameters:
 
 
 definitions:
+
+  PatchRequest:
+    type: object
+    properties:
+      resource:
+        type: string
+      changes:
+        type: array
+        items:
+          type: object
+          properties:
+            op:
+              type: string
+              enum: ["add", "remove", "replace", "test", "copy", "move"]
+            path:
+              type: string
+            from:
+              type: string
+            value: {}
+          required:
+            - op
+            - path
+    required:
+    - resource
+    - changes
 
   CreateMeetingRoomRequest:
     type: object
@@ -407,9 +514,15 @@ definitions:
       createdAt:
         type: string
         format: date-time
+      participants:
+        type: array
+        items:
+          description: userId
+          type: string
     required:
       - meetingId
       - name
+      - participants
       - startDateTime
       - endDateTime
       - createdAt

--- a/swagger.yml
+++ b/swagger.yml
@@ -46,6 +46,18 @@ paths:
           description: resource available in room
           type: string
           required: false
+        - in: query
+          name: availableFrom
+          description: availability window start datetime
+          type: string
+          format: date-time
+          required: false
+        - in: query
+          name: availableTo
+          description: availability window end datetime
+          type: string
+          format: date-time
+          required: false
       tags:
         - Rooms
       responses:

--- a/swagger.yml
+++ b/swagger.yml
@@ -40,6 +40,12 @@ paths:
 
     get:
       summary: Retrieve List of Meeting Room Records
+      parameters:
+        - in: query
+          name: resources
+          description: resource available in room
+          type: string
+          required: false
       tags:
         - Rooms
       responses:


### PR DESCRIPTION
changes: 
- initial commit of swagger spec
- added swagger validation badge to README

I still need to add the optional query parameters to the ``/api/room`` endpoint to allow for filtering by time availability and available resources.

example:
``/api/room?resource=projector&availableStartTime=2018-03-26T10%3A00%3A00Z&availableEndTime=2018-03-26T11%3A00%3A00Z``

would return a list of rooms available for the given time range that contain a projector

We will also want to define some query parameters for searching for users by name, email, etc.

- ``/api/user?email=zednis@rpi.edu``
- ``/api/user?givenName=Stephan``
- ``/api/user?familyName=Zednik``

To view the generated documentation from this spec copy & paste the contents of swagger.yml into the editor pane on https://editor.swagger.io

closes https://github.com/zednis/alexa-skill-meeting-scheduler/issues/27

cc: @omerosman