### PR TITLE
add name-based search to /api/rooms

### DIFF
--- a/api.js
+++ b/api.js
@@ -330,6 +330,10 @@ exports.getRooms = function(parameters) {
     const joins = [];
     const constraints = [];
 
+    if(parameters.hasOwnProperty("nameContains")) {
+        constraints.push("LOWER(MR.name) like "+ db.pool.escape("%"+parameters.nameContains.toLowerCase()+"%"))
+    }
+
     if(parameters.hasOwnProperty("resources")) {
         joins.push("JOIN ebdb.RoomResourceMeetingRoomAssociation RRMRA  on RRMRA.room = MR.id");
         joins.push("JOIN ebdb.RoomResource RR on RRMRA.resource = RR.id");

--- a/swagger.yml
+++ b/swagger.yml
@@ -60,8 +60,8 @@ paths:
           format: date-time
           required: false
         - in: query
-          name: roomName
-          description: room name
+          name: nameContains
+          description: room name search parameter
           type: string
           required: false
       tags:


### PR DESCRIPTION
changes
- added nameContains query parameter to /api/rooms endpoint

implements a case-insensitive regex query on MeetingRoom.name.

request:
```
127.0.0.1:3000/api/rooms?nameContains=pikes
```

response:
```
{"items":[{"roomId":1,"name":"Pikes Peak","resources":["whiteboard","projector","test"]}]}
```

